### PR TITLE
Add Driver/Constructor rankings as chapters (#50)

### DIFF
--- a/documentation/SESSIONS_CHAPTERS_FEATURE.md
+++ b/documentation/SESSIONS_CHAPTERS_FEATURE.md
@@ -8,10 +8,12 @@ The Yoto F1 Card Generator now creates separate chapters for each session of an 
 
 ### Data Sources
 
-The app uses two primary endpoints from the [OpenF1 API](https://openf1.org/):
+The app uses several endpoints from the [OpenF1 API](https://openf1.org/):
 
 1. **Meetings API** (`/v1/meetings`) - Gets information about the race weekend
 2. **Sessions API** (`/v1/sessions`) - Retrieves all sessions for a specific meeting
+3. **Drivers Championship API** (`/v1/championship_drivers`, beta) - Current top 5 drivers, as of the most recently completed Race session
+4. **Teams Championship API** (`/v1/championship_teams`, beta) - Current top 5 constructors, as of the most recently completed Race session
 
 ### Chapter Structure
 
@@ -32,6 +34,18 @@ A separate chapter for each upcoming session:
 - **Qualifying** - Explanation of the knockout format (Q1, Q2, Q3) and grid determination
 - **Sprint** - Information about sprint race format and points (if scheduled)
 - **Race** - Complete Grand Prix details with strategy notes
+
+#### Chapter: Top 5 Drivers
+
+- Current top 5 in the Drivers' Championship
+- One track per driver, in position order
+- Each track displays the driver's constructor car icon (see [Custom Icons](#custom-icons))
+
+#### Chapter: Top 5 Constructors
+
+- Current top 5 in the Constructors' Championship
+- One track per team, in position order
+- Each track displays that team's car icon (see [Custom Icons](#custom-icons))
 
 ### Session Information
 
@@ -189,13 +203,14 @@ sessions = rawSessions.map(session => ({
 
 ## Custom Icons
 
-Each chapter and track displays a custom F1 race car icon on your Yoto player:
+Each chapter and track displays a custom icon on your Yoto player:
 
-1. Icon file: `public/assets/card-images/countdown-to-f1-icon.png`
-2. Automatically uploaded to Yoto with `autoConvert=true`
-3. Resized to 16×16 pixels by Yoto API
-4. Stored as `yoto:#{mediaId}` format
-5. Applied to all chapters and tracks
+1. Race weekend and session chapters use the generic icon: `public/assets/card-images/countdown-to-f1-icon.png`
+2. Driver and constructor standings tracks use a team-specific car icon when one exists: `ferrari.png`, `mclaren.png`, `mercedes.png`, `redbull.png` (in `public/assets/card-images/`). Teams without a dedicated icon fall back to the generic icon.
+3. Icons are automatically uploaded to Yoto with `autoConvert=true`
+4. Resized to 16×16 pixels by Yoto API
+5. Stored as `yoto:#{mediaId}` format
+6. Team icons are uploaded once per unique file per request (`uploadTeamCarIcons` in `src/utils/imageUtils.js`), even if multiple drivers share a team
 
 ## Debugging
 
@@ -233,7 +248,6 @@ To verify the chapters are working:
 
 Potential improvements:
 
-- Add driver and team standings as additional chapters
 - Include weather forecasts for each session
 - Add qualifying results after Q3 completes
 - Real-time session updates during race weekend

--- a/public/assets/card-images/README.md
+++ b/public/assets/card-images/README.md
@@ -18,6 +18,8 @@ This directory stores card cover images that will be uploaded to Yoto and displa
 ## Current Images
 
 - `countdown-to-f1-card.png` - Default F1 card cover (replace with your own image using this filename)
+- `countdown-to-f1-icon.png` - Generic 16x16 icon used for race weekend and session chapters
+- `ferrari.png`, `mclaren.png`, `mercedes.png`, `redbull.png` - Team car icons used on the Top 5 Drivers and Top 5 Constructors chapter tracks (see `src/utils/imageUtils.js#getTeamCarIconFilename`). Teams without a matching file fall back to the generic icon.
 
 ## API Reference
 

--- a/src/app/api/generate-card/route.js
+++ b/src/app/api/generate-card/route.js
@@ -1,7 +1,7 @@
 // API Route to generate a Formula 1 card
 import { getNextRace, getUpcomingSessions, getDriverStandings, getTeamStandings, generateF1Script, getMeetingDetails, getSessionWeather } from "@/services/f1Service";
 import { createTextToSpeechPlaylist, buildF1Chapters, deployToAllDevices } from "@/services/yotoService";
-import { uploadCardIcon, uploadCountryFlagIcon } from "@/utils/imageUtils";
+import { uploadCardIcon, uploadCountryFlagIcon, uploadTeamCarIcons } from "@/utils/imageUtils";
 import { getAccessToken, getStoredCardId, storeCardId, isAuthError, createAuthErrorResponse } from "@/utils/authUtils";
 
 // Increase max listeners to handle multiple AbortSignal.timeout() calls
@@ -215,8 +215,18 @@ export async function POST(request) {
       countryFlagIconId = await uploadCountryFlagIcon(raceData.countryFlag, accessToken, raceData.country);
     }
 
+    // Step 7b: Upload team-specific car icons for the driver/constructor standings chapters
+    const teamIconMap = await uploadTeamCarIcons(
+      [...driverStandings.map(d => d.team), ...teamStandings.map(t => t.team)],
+      accessToken
+    );
+
     // Step 8: Build chapters for Yoto playlist with custom icon, sessions, and enhanced details
-    const chapters = buildF1Chapters(raceData, sessions, iconMediaId, weather, countryFlagIconId);
+    const chapters = buildF1Chapters(raceData, sessions, iconMediaId, weather, countryFlagIconId, {
+      driverStandings,
+      teamStandings,
+      teamIconMap,
+    });
 
     // Step 9: Return success with generated data (not sent to Yoto yet)
     return Response.json({

--- a/src/app/api/refresh-myo-playlist/route.js
+++ b/src/app/api/refresh-myo-playlist/route.js
@@ -2,8 +2,9 @@
 // This endpoint fetches fresh F1 data from the Cloudflare worker and creates
 // a new MYO playlist via the Yoto Labs TTS API when data has changed.
 
+import { getDriverStandings, getTeamStandings } from "@/services/f1Service";
 import { createTextToSpeechPlaylist, buildF1Chapters, deployToAllDevices } from "@/services/yotoService";
-import { uploadCardIcon, uploadCountryFlagIcon, uploadCardCoverImage } from "@/utils/imageUtils";
+import { uploadCardIcon, uploadCountryFlagIcon, uploadCardCoverImage, uploadTeamCarIcons } from "@/utils/imageUtils";
 import { getAccessToken, getStoredCardId, storeCardId, getStoredPlaylistTitle, storePlaylistTitle, isAuthError, createAuthErrorResponse, getStoredDataHash, storeDataHash } from "@/utils/authUtils";
 
 /**
@@ -143,8 +144,23 @@ export async function POST(request) {
     // Step 8: Upload cover image if available
     const coverImageUrl = await uploadCardCoverImage(accessToken);
 
+    // Step 8b: Fetch current driver & constructor standings for additional chapters
+    const driverStandings = await getDriverStandings();
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const teamStandings = await getTeamStandings();
+
+    // Step 8c: Upload team-specific car icons for the standings chapters
+    const teamIconMap = await uploadTeamCarIcons(
+      [...driverStandings.map(d => d.team), ...teamStandings.map(t => t.team)],
+      accessToken
+    );
+
     // Step 9: Build chapters with fresh data
-    const chapters = buildF1Chapters(raceData, formattedSessions, iconMediaId, weather, countryFlagIconId);
+    const chapters = buildF1Chapters(raceData, formattedSessions, iconMediaId, weather, countryFlagIconId, {
+      driverStandings,
+      teamStandings,
+      teamIconMap,
+    });
 
     // Step 10: Get stored card ID and playlist title (if exists)
     const existingCardId = getStoredCardId();

--- a/src/app/api/webhook/refresh-playlist/route.js
+++ b/src/app/api/webhook/refresh-playlist/route.js
@@ -2,8 +2,9 @@
 // This endpoint can be called by external services (e.g., cron jobs, CI/CD) to trigger playlist updates
 // Uses a secret token for authentication
 
+import { getDriverStandings, getTeamStandings } from "@/services/f1Service";
 import { createTextToSpeechPlaylist, buildF1Chapters, deployToAllDevices } from "@/services/yotoService";
-import { uploadCardIcon, uploadCountryFlagIcon, uploadCardCoverImage } from "@/utils/imageUtils";
+import { uploadCardIcon, uploadCountryFlagIcon, uploadCardCoverImage, uploadTeamCarIcons } from "@/utils/imageUtils";
 import { getAccessToken, refreshAccessToken, getStoredTokens, getStoredCardId, storeCardId, getStoredPlaylistTitle, storePlaylistTitle, getStoredDataHash, storeDataHash } from "@/utils/authUtils";
 
 /**
@@ -234,8 +235,23 @@ export async function POST(request) {
     // Step 7: Upload cover image if available
     const coverImageUrl = await uploadCardCoverImage(accessToken);
 
+    // Step 7b: Fetch current driver & constructor standings for additional chapters
+    const driverStandings = await getDriverStandings();
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const teamStandings = await getTeamStandings();
+
+    // Step 7c: Upload team-specific car icons for the standings chapters
+    const teamIconMap = await uploadTeamCarIcons(
+      [...driverStandings.map(d => d.team), ...teamStandings.map(t => t.team)],
+      accessToken
+    );
+
     // Step 8: Build chapters
-    const chapters = buildF1Chapters(raceData, formattedSessions, iconMediaId, weather, countryFlagIconId);
+    const chapters = buildF1Chapters(raceData, formattedSessions, iconMediaId, weather, countryFlagIconId, {
+      driverStandings,
+      teamStandings,
+      teamIconMap,
+    });
 
     // Step 9: Get stored card ID and playlist title (if exists)
     const existingCardId = getStoredCardId();

--- a/src/services/f1Service.js
+++ b/src/services/f1Service.js
@@ -133,67 +133,76 @@ export async function getUpcomingSessions(meetingKey) {
 }
 
 /**
+ * Find the most recently completed Race session. Championship standings
+ * (points_current/position_current) are calculated as of a specific session,
+ * so we need a session that has actually happened to have any data.
+ */
+async function getLatestCompletedRaceSession() {
+  const now = new Date();
+
+  const fetchRaceSessions = async (year) => {
+    const response = await fetch(
+      `${F1_API_BASE}/sessions?session_name=Race&year=${year}`,
+      { signal: AbortSignal.timeout(5000) }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch race sessions for ${year}`);
+    }
+
+    return response.json();
+  };
+
+  const completedSessions = (sessions) => (sessions || [])
+    .filter(s => new Date(s.date_start) <= now)
+    .sort((a, b) => new Date(a.date_start) - new Date(b.date_start));
+
+  let completed = completedSessions(await fetchRaceSessions(now.getFullYear()));
+
+  if (completed.length === 0) {
+    // No races have happened yet this year (e.g. off-season) — fall back to
+    // the previous year's final standings.
+    await new Promise(resolve => setTimeout(resolve, 500));
+    completed = completedSessions(await fetchRaceSessions(now.getFullYear() - 1));
+  }
+
+  if (completed.length === 0) {
+    throw new Error("No completed race sessions found");
+  }
+
+  return completed[completed.length - 1];
+}
+
+/**
  * Get current driver standings (top 5)
+ * Uses the OpenF1 Drivers Championship (beta) endpoint.
+ * https://openf1.org/#drivers-championship-beta
  */
 export async function getDriverStandings() {
   try {
-    const currentYear = new Date().getFullYear();
-    const currentMonth = new Date().getMonth(); // 0-11
-    
-    // If we're before March (month 2), use previous year's final standings
-    const yearToUse = currentMonth < 2 ? currentYear - 1 : currentYear;
-    
-    console.log(`Fetching driver standings for year: ${yearToUse}`);
-    
-    // Get the last race session of the season to get final standings
-    const sessionsResponse = await fetch(
-      `${F1_API_BASE}/sessions?session_name=Race&year=${yearToUse}`,
+    const lastSession = await getLatestCompletedRaceSession();
+
+    // Rate limit protection before next API call
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const championshipResponse = await fetch(
+      `${F1_API_BASE}/championship_drivers?session_key=${lastSession.session_key}`,
       { signal: AbortSignal.timeout(5000) }
     );
 
-    if (!sessionsResponse.ok) {
-      throw new Error("Failed to fetch race sessions");
+    if (!championshipResponse.ok) {
+      throw new Error("Failed to fetch driver championship data");
     }
 
-    const sessions = await sessionsResponse.json();
-    
-    if (!sessions || sessions.length === 0) {
-      throw new Error("No race sessions found");
+    const championship = await championshipResponse.json();
+
+    if (!championship || championship.length === 0) {
+      throw new Error("No driver championship data found");
     }
-    
-    // Get the last race session
-    const lastSession = sessions[sessions.length - 1];
-    
+
     // Rate limit protection before next API call
     await new Promise(resolve => setTimeout(resolve, 500));
-    
-    // Fetch position data from the last session to get championship standings
-    const positionResponse = await fetch(
-      `${F1_API_BASE}/position?session_key=${lastSession.session_key}`,
-      { signal: AbortSignal.timeout(5000) }
-    );
 
-    if (!positionResponse.ok) {
-      throw new Error("Failed to fetch position data");
-    }
-
-    const positions = await positionResponse.json();
-    
-    if (!positions || positions.length === 0) {
-      throw new Error("No position data found");
-    }
-    
-    // Get the final position (last timestamp) for each driver
-    const driverFinalPositions = new Map();
-    
-    positions.forEach(pos => {
-      const existing = driverFinalPositions.get(pos.driver_number);
-      if (!existing || new Date(pos.date) > new Date(existing.date)) {
-        driverFinalPositions.set(pos.driver_number, pos);
-      }
-    });
-    // Rate limit protection before next API call
-    await new Promise(resolve => setTimeout(resolve, 500));
     // Fetch driver details to get names and teams
     const driversResponse = await fetch(
       `${F1_API_BASE}/drivers?session_key=${lastSession.session_key}`,
@@ -205,25 +214,20 @@ export async function getDriverStandings() {
     }
 
     const drivers = await driversResponse.json();
-    const driverMap = new Map(
-      drivers.map(d => [d.driver_number, d])
-    );
-    
-    // Sort by final position and take top 5
-    const sortedPositions = Array.from(driverFinalPositions.values())
-      .sort((a, b) => a.position - b.position)
-      .slice(0, 5);
-    
-    // Map to driver standings format
-    return sortedPositions.map((pos, index) => {
-      const driver = driverMap.get(pos.driver_number);
-      return {
-        position: pos.position || (index + 1),
-        driver: driver ? (driver.full_name || `${driver.first_name} ${driver.last_name}`) : `Driver ${pos.driver_number}`,
-        team: driver?.team_name || "Unknown Team",
-        points: Math.max(500 - (pos.position - 1) * 50, 0) // Estimated points based on position
-      };
-    });
+    const driverMap = new Map(drivers.map(d => [d.driver_number, d]));
+
+    return championship
+      .sort((a, b) => a.position_current - b.position_current)
+      .slice(0, 5)
+      .map(entry => {
+        const driver = driverMap.get(entry.driver_number);
+        return {
+          position: entry.position_current,
+          driver: driver ? (driver.full_name || `${driver.first_name} ${driver.last_name}`) : `Driver ${entry.driver_number}`,
+          team: driver?.team_name || "Unknown Team",
+          points: entry.points_current,
+        };
+      });
   } catch (error) {
     console.log("Using mock driver standings due to API error:", error.message);
     return MOCK_DATA.drivers;
@@ -232,71 +236,39 @@ export async function getDriverStandings() {
 
 /**
  * Get current constructor/team standings (top 5)
+ * Uses the OpenF1 Teams Championship (beta) endpoint.
+ * https://openf1.org/#teams-championship-beta
  */
 export async function getTeamStandings() {
   try {
-    const currentYear = new Date().getFullYear();
-    const currentMonth = new Date().getMonth(); // 0-11
-    
-    // If we're before March (month 2), use previous year's final standings
-    const yearToUse = currentMonth < 2 ? currentYear - 1 : currentYear;
-    
-    console.log(`Fetching team standings for year: ${yearToUse}`);
-    
-    // Get the last race session of the season
-    const sessionsResponse = await fetch(
-      `${F1_API_BASE}/sessions?session_name=Race&year=${yearToUse}`,
-      { signal: AbortSignal.timeout(5000) }
-    );
+    const lastSession = await getLatestCompletedRaceSession();
 
-    if (!sessionsResponse.ok) {
-      throw new Error("Failed to fetch race sessions");
-    }
-
-    const sessions = await sessionsResponse.json();
-    
-    if (!sessions || sessions.length === 0) {
-      throw new Error("No race sessions found");
-    }
-    
-    // Get the last race session
-    const lastSession = sessions[sessions.length - 1];
-    
     // Rate limit protection before next API call
     await new Promise(resolve => setTimeout(resolve, 500));
-    
-    // Fetch drivers from the last session to extract teams
-    const driversResponse = await fetch(
-      `${F1_API_BASE}/drivers?session_key=${lastSession.session_key}`,
+
+    const championshipResponse = await fetch(
+      `${F1_API_BASE}/championship_teams?session_key=${lastSession.session_key}`,
       { signal: AbortSignal.timeout(5000) }
     );
 
-    if (!driversResponse.ok) {
-      throw new Error("Failed to fetch team data");
+    if (!championshipResponse.ok) {
+      throw new Error("Failed to fetch team championship data");
     }
 
-    const drivers = await driversResponse.json();
-    
-    if (!drivers || drivers.length === 0) {
-      throw new Error("No team data found");
+    const championship = await championshipResponse.json();
+
+    if (!championship || championship.length === 0) {
+      throw new Error("No team championship data found");
     }
-    
-    // Extract unique teams
-    const uniqueTeams = Array.from(
-      new Map(drivers.map(d => [d.team_name, d])).values()
-    );
-    
-    // Create team standings with mock points
-    const teamStandings = uniqueTeams
-      .filter(d => d.team_name) // Only include teams with names
+
+    return championship
+      .sort((a, b) => a.position_current - b.position_current)
       .slice(0, 5)
-      .map((driver, index) => ({
-        position: index + 1,
-        team: driver.team_name,
-        points: 860 - (index * 100) // Mock points (API doesn't provide standings)
+      .map(entry => ({
+        position: entry.position_current,
+        team: entry.team_name,
+        points: entry.points_current,
       }));
-    
-    return teamStandings.length > 0 ? teamStandings : MOCK_DATA.teams;
   } catch (error) {
     console.log("Using mock team standings due to API error:", error.message);
     return MOCK_DATA.teams;

--- a/src/services/yotoService.js
+++ b/src/services/yotoService.js
@@ -536,9 +536,14 @@ export async function deployToAllDevices(cardId, accessToken) {
  * @param {string|null} iconMediaId - Optional custom icon media ID (from uploadCardIcon)
  * @param {Object|null} weather - Optional weather data (temperature, humidity, wind, rainfall)
  * @param {string|null} countryFlagIconId - Optional country flag icon media ID for first chapter
+ * @param {Object} [standings] - Optional championship standings for additional chapters
+ * @param {Array} [standings.driverStandings] - Top driver standings from getDriverStandings()
+ * @param {Array} [standings.teamStandings] - Top constructor standings from getTeamStandings()
+ * @param {Map<string,string>} [standings.teamIconMap] - Map of team name -> car icon media ID (from uploadTeamCarIcons)
  * @returns {Array} Array of chapter objects
  */
-export function buildF1Chapters(raceData, sessions = [], iconMediaId = null, weather = null, countryFlagIconId = null) {
+export function buildF1Chapters(raceData, sessions = [], iconMediaId = null, weather = null, countryFlagIconId = null, standings = {}) {
+  const { driverStandings = [], teamStandings = [], teamIconMap = new Map() } = standings;
   const chapters = [];
   
   console.log(`Building F1 chapters with ${sessions.length} sessions, iconMediaId: ${iconMediaId || 'none'}, weather: ${weather ? 'yes' : 'no'}, countryFlagIconId: ${countryFlagIconId || 'none'}`);
@@ -655,6 +660,40 @@ Get ready for an exciting race at ${raceData.circuit}!`,
         }
       ]
     };
+  }
+
+  // Chapter: Top 5 Drivers - one track per driver, each with its constructor's car icon
+  if (driverStandings.length > 0) {
+    const leaderIcon = teamIconMap.get(driverStandings[0].team) || iconMediaId;
+    chapters.push({
+      title: "Top 5 Drivers",
+      icon: leaderIcon ? `yoto:#${leaderIcon}` : null,
+      tracks: driverStandings.map(entry => {
+        const trackIcon = teamIconMap.get(entry.team) || iconMediaId;
+        return {
+          title: `P${entry.position}: ${entry.driver}`,
+          text: `In position ${entry.position}, ${entry.driver} driving for ${entry.team}, with ${entry.points} points.`,
+          icon: trackIcon ? `yoto:#${trackIcon}` : null,
+        };
+      }),
+    });
+  }
+
+  // Chapter: Top 5 Constructors - one track per team, each with its car icon
+  if (teamStandings.length > 0) {
+    const leaderIcon = teamIconMap.get(teamStandings[0].team) || iconMediaId;
+    chapters.push({
+      title: "Top 5 Constructors",
+      icon: leaderIcon ? `yoto:#${leaderIcon}` : null,
+      tracks: teamStandings.map(entry => {
+        const trackIcon = teamIconMap.get(entry.team) || iconMediaId;
+        return {
+          title: `P${entry.position}: ${entry.team}`,
+          text: `In position ${entry.position}, ${entry.team}, with ${entry.points} points.`,
+          icon: trackIcon ? `yoto:#${trackIcon}` : null,
+        };
+      }),
+    });
   }
 
   console.log(`Built ${chapters.length} total chapters for F1 card`);

--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -70,6 +70,108 @@ export async function uploadCardIcon(accessToken) {
 }
 
 /**
+ * Map an F1 constructor name to its car icon filename in
+ * public/assets/card-images, if a team-specific icon exists.
+ * @param {string} teamName - F1 constructor name (e.g. "Red Bull Racing")
+ * @returns {string|null} Icon filename, or null if no team-specific icon exists
+ */
+export function getTeamCarIconFilename(teamName) {
+  if (!teamName) return null;
+  const normalized = teamName.toLowerCase();
+
+  if (normalized.includes('ferrari')) return 'ferrari.png';
+  if (normalized.includes('mclaren')) return 'mclaren.png';
+  if (normalized.includes('mercedes')) return 'mercedes.png';
+  if (normalized.includes('red bull')) return 'redbull.png';
+
+  return null;
+}
+
+/**
+ * Upload a team's car icon (16x16) if a matching icon file exists.
+ * @param {string} teamName - F1 constructor name (e.g. "Red Bull Racing")
+ * @param {string} accessToken - Yoto API access token
+ * @returns {Promise<string|null>} Media ID of uploaded icon, or null if unavailable
+ */
+export async function uploadTeamCarIcon(teamName, accessToken) {
+  const iconName = getTeamCarIconFilename(teamName);
+  if (!iconName) {
+    return null;
+  }
+
+  try {
+    const publicDir = join(process.cwd(), 'public', 'assets', 'card-images');
+    const iconPath = join(publicDir, iconName);
+    const iconBuffer = readFileSync(iconPath);
+
+    console.log(`Found team icon for "${teamName}": ${iconName}, uploading to Yoto...`);
+
+    const url = new URL('https://api.yotoplay.com/media/displayIcons/user/me/upload');
+    url.searchParams.set('autoConvert', 'true');
+    url.searchParams.set('filename', iconName.replace(/\.[^/.]+$/, ''));
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'image/png',
+      },
+      body: iconBuffer,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      if (errorText.includes('not authorized') || errorText.includes('explicit deny')) {
+        console.log('Note: Custom icon uploads require special API permissions. Continuing without team icon.');
+        return null;
+      }
+      throw new Error(`Team icon upload failed: ${errorText}`);
+    }
+
+    const result = await response.json();
+    const mediaId = result.displayIcon?.mediaId;
+
+    if (!mediaId) {
+      throw new Error('No mediaId in upload response');
+    }
+
+    console.log(`Team icon uploaded for "${teamName}" with mediaId: ${mediaId}`);
+    return mediaId;
+  } catch (error) {
+    console.log(`Could not upload team icon for "${teamName}": ${error.message}`);
+    return null;
+  }
+}
+
+/**
+ * Upload car icons for a set of teams, deduplicating by icon file so each
+ * icon file is only uploaded once even when multiple drivers share a team.
+ * @param {string[]} teamNames
+ * @param {string} accessToken - Yoto API access token
+ * @returns {Promise<Map<string, string>>} Map of team name -> media ID (only teams with a matching icon are included)
+ */
+export async function uploadTeamCarIcons(teamNames, accessToken) {
+  const mediaIdsByIconFile = new Map();
+  const mediaIdsByTeam = new Map();
+
+  for (const teamName of new Set((teamNames || []).filter(Boolean))) {
+    const iconName = getTeamCarIconFilename(teamName);
+    if (!iconName) continue;
+
+    if (!mediaIdsByIconFile.has(iconName)) {
+      mediaIdsByIconFile.set(iconName, await uploadTeamCarIcon(teamName, accessToken));
+    }
+
+    const mediaId = mediaIdsByIconFile.get(iconName);
+    if (mediaId) {
+      mediaIdsByTeam.set(teamName, mediaId);
+    }
+  }
+
+  return mediaIdsByTeam;
+}
+
+/**
  * Download and upload country flag as icon
  * @param {string} flagUrl - URL to the country flag image
  * @param {string} accessToken - Yoto API access token


### PR DESCRIPTION
Switches driver/team standings from a hand-rolled points estimate based on position data to OpenF1's real Drivers Championship and Teams Championship (beta) endpoints, resolved against the most recently completed race session so standings stay accurate mid-season.

Wires the standings into buildF1Chapters as two new chapters (Top 5 Drivers, Top 5 Constructors), one track per entry, using the existing team car icons in public/assets/card-images (ferrari, mclaren, mercedes, redbull) with a generic fallback icon for other teams. Previously this data was fetched but only used for an unsent preview script — it never reached the actual Yoto playlist.