### PR TITLE
Fix 500 error on Send to Yoto by refreshing stale access tokens

### DIFF
--- a/src/app/api/generate-card/route.js
+++ b/src/app/api/generate-card/route.js
@@ -2,7 +2,7 @@
 import { getNextRace, getUpcomingSessions, getDriverStandings, getTeamStandings, generateF1Script, getMeetingDetails, getSessionWeather } from "@/services/f1Service";
 import { createTextToSpeechPlaylist, buildF1Chapters, deployToAllDevices } from "@/services/yotoService";
 import { uploadCardIcon, uploadCountryFlagIcon, uploadTeamCarIcons } from "@/utils/imageUtils";
-import { getAccessToken, getStoredCardId, storeCardId, isAuthError, createAuthErrorResponse } from "@/utils/authUtils";
+import { getValidAccessToken, getStoredCardId, storeCardId, isAuthError, createAuthErrorResponse } from "@/utils/authUtils";
 
 // Increase max listeners to handle multiple AbortSignal.timeout() calls
 // Each OpenF1 API call uses AbortSignal.timeout(5000) which adds event listeners
@@ -46,9 +46,13 @@ async function getUserTimezone(request) {
 
 export async function POST(request) {
   try {
-    // Step 1: Check if user is authenticated
-    const accessToken = getAccessToken();
+    // Step 1: Check if user is authenticated, refreshing the token first since
+    // Yoto access tokens expire daily and a stale token causes an opaque 500.
+    const { accessToken, reauthRequired } = await getValidAccessToken();
     if (!accessToken) {
+      if (reauthRequired) {
+        return createAuthErrorResponse();
+      }
       return Response.json(
         {
           error: "Not authenticated. Please connect with Yoto first.",

--- a/src/app/api/job-status/route.js
+++ b/src/app/api/job-status/route.js
@@ -1,12 +1,16 @@
 // API Route to check TTS job status
 import { checkJobStatus } from "@/services/yotoService";
-import { getAccessToken, isAuthError, createAuthErrorResponse } from "@/utils/authUtils";
+import { getValidAccessToken, isAuthError, createAuthErrorResponse } from "@/utils/authUtils";
 
 export async function GET(request) {
   try {
-    // Check if user is authenticated
-    const accessToken = getAccessToken();
+    // Check if user is authenticated, refreshing the token first since Yoto
+    // access tokens expire daily and a stale token causes an opaque 500.
+    const { accessToken, reauthRequired } = await getValidAccessToken();
     if (!accessToken) {
+      if (reauthRequired) {
+        return createAuthErrorResponse();
+      }
       return Response.json(
         {
           error: "Not authenticated. Please connect with Yoto first.",

--- a/src/app/api/refresh-myo-playlist/route.js
+++ b/src/app/api/refresh-myo-playlist/route.js
@@ -5,7 +5,7 @@
 import { getDriverStandings, getTeamStandings } from "@/services/f1Service";
 import { createTextToSpeechPlaylist, buildF1Chapters, deployToAllDevices } from "@/services/yotoService";
 import { uploadCardIcon, uploadCountryFlagIcon, uploadCardCoverImage, uploadTeamCarIcons } from "@/utils/imageUtils";
-import { getAccessToken, getStoredCardId, storeCardId, getStoredPlaylistTitle, storePlaylistTitle, isAuthError, createAuthErrorResponse, getStoredDataHash, storeDataHash } from "@/utils/authUtils";
+import { getValidAccessToken, getStoredCardId, storeCardId, getStoredPlaylistTitle, storePlaylistTitle, isAuthError, createAuthErrorResponse, getStoredDataHash, storeDataHash } from "@/utils/authUtils";
 
 /**
  * Refresh MYO playlist with latest data from Cloudflare Worker.
@@ -14,9 +14,13 @@ import { getAccessToken, getStoredCardId, storeCardId, getStoredPlaylistTitle, s
  */
 export async function POST(request) {
   try {
-    // Step 1: Check authentication
-    const accessToken = getAccessToken();
+    // Step 1: Check authentication, refreshing the token first since Yoto
+    // access tokens expire daily and a stale token causes an opaque 500.
+    const { accessToken, reauthRequired } = await getValidAccessToken();
     if (!accessToken) {
+      if (reauthRequired) {
+        return createAuthErrorResponse();
+      }
       return Response.json(
         { error: "Not authenticated. Please connect with Yoto first.", needsAuth: true },
         { status: 401 }

--- a/src/app/api/send-to-yoto/route.js
+++ b/src/app/api/send-to-yoto/route.js
@@ -1,13 +1,17 @@
 // API Route to send generated card data to Yoto
 import { createOrUpdateTTSPlaylist, deployToAllDevices } from "@/services/yotoService";
 import { uploadCardCoverImage } from "@/utils/imageUtils";
-import { getAccessToken, getStoredCardId, storeCardId, storePlaylistTitle, isAuthError, createAuthErrorResponse } from "@/utils/authUtils";
+import { getValidAccessToken, getStoredCardId, storeCardId, storePlaylistTitle, isAuthError, createAuthErrorResponse } from "@/utils/authUtils";
 
 export async function POST(request) {
   try {
-    // Step 1: Check if user is authenticated
-    const accessToken = getAccessToken();
+    // Step 1: Check if user is authenticated, refreshing the token first since
+    // Yoto access tokens expire daily and a stale token causes an opaque 500.
+    const { accessToken, reauthRequired } = await getValidAccessToken();
     if (!accessToken) {
+      if (reauthRequired) {
+        return createAuthErrorResponse();
+      }
       return Response.json(
         {
           error: "Not authenticated. Please connect with Yoto first.",

--- a/src/app/api/upload-to-myo/route.js
+++ b/src/app/api/upload-to-myo/route.js
@@ -1,13 +1,17 @@
 // API Route to upload audio to MYO card
 import { requestAudioUploadUrl, uploadAudioFile, waitForTranscoding, createAudioCard } from "@/services/yotoService";
 import { uploadCardCoverImage } from "@/utils/imageUtils";
-import { getAccessToken, isAuthError, createAuthErrorResponse, getStoredMyoCardId, storeMyoCardId } from "@/utils/authUtils";
+import { getValidAccessToken, isAuthError, createAuthErrorResponse, getStoredMyoCardId, storeMyoCardId } from "@/utils/authUtils";
 
 export async function POST(request) {
   try {
-    // Check authentication
-    const accessToken = getAccessToken();
+    // Check authentication, refreshing the token first since Yoto access
+    // tokens expire daily and a stale token causes an opaque 500.
+    const { accessToken, reauthRequired } = await getValidAccessToken();
     if (!accessToken) {
+      if (reauthRequired) {
+        return createAuthErrorResponse();
+      }
       return Response.json(
         { error: "Not authenticated. Please connect with Yoto first.", needsAuth: true },
         { status: 401 }

--- a/src/utils/authUtils.js
+++ b/src/utils/authUtils.js
@@ -168,15 +168,52 @@ export async function refreshAccessToken() {
 }
 
 /**
+ * Get a usable access token, refreshing it first when possible.
+ *
+ * Yoto access tokens expire daily. Calling Yoto's API with a stale token
+ * doesn't return a clean 401 — it returns a generic authorizer denial
+ * ("User is not authorized to access this resource with an explicit deny
+ * in an identity-based policy"), which looks like a permissions/500 error.
+ * Routes should call this instead of getAccessToken() directly.
+ *
+ * @returns {Promise<{accessToken: string|null, reauthRequired: boolean}>}
+ */
+export async function getValidAccessToken() {
+  const accessToken = getAccessToken();
+  if (!accessToken) {
+    return { accessToken: null, reauthRequired: false };
+  }
+
+  const refreshedToken = await refreshAccessToken();
+  if (refreshedToken) {
+    return { accessToken: refreshedToken, reauthRequired: false };
+  }
+
+  const storedTokens = getStoredTokens();
+  if (storedTokens?.refreshToken) {
+    // Refresh token was available but refresh failed — token may be revoked
+    console.error('[Auth] Token refresh failed with an existing refresh token');
+    return { accessToken: null, reauthRequired: true };
+  }
+
+  // No refresh token available (e.g. legacy auth); fall back to existing access token
+  return { accessToken, reauthRequired: false };
+}
+
+/**
  * Handle authentication errors consistently
  * @param {Error} error - The error object
  * @returns {boolean} - True if it's an authentication error
  */
 export function isAuthError(error) {
+  const message = typeof error.message === 'string' ? error.message.toLowerCase() : '';
   return (
     error.status === 401 ||
-    (error.message && typeof error.message === 'string' && 
-     (error.message.includes('401') || error.message.toLowerCase().includes('unauthorized')))
+    error.status === 403 ||
+    message.includes('401') ||
+    message.includes('unauthorized') ||
+    message.includes('explicit deny') ||
+    message.includes('not authorized to access this resource')
   );
 }
 


### PR DESCRIPTION
## Summary
- Clicking **Send to Yoto** was failing with a 500 error: `Failed to get upload URL: {"Message":"User is not authorized to access this resource with an explicit deny in an identity-based policy"}`. This is Yoto's generic API Gateway authorizer denial message — it fires for expired/invalid tokens, not just missing permissions.
- Yoto access tokens expire daily. The `/api/webhook/refresh-playlist` cron route already refreshes the token before use, but the interactive routes (`send-to-yoto`, `generate-card`, `refresh-myo-playlist`, `upload-to-myo`, `job-status`) read the stored token as-is, so a token that had gone stale since the last login produced this opaque error instead of a clean re-auth prompt.
- Extracted the refresh-then-fallback logic into `getValidAccessToken()` in `authUtils.js` and switched all the interactive routes to use it. If the refresh token itself has been revoked, the user now gets a proper "reconnect with Yoto" response instead of a raw 500.
- Widened `isAuthError()` to also recognize 403 / "explicit deny" responses so a genuinely revoked token still surfaces as a clean reconnect prompt.

## Test plan
- [x] `npm run build` passes
- [ ] Click "Send to Yoto" in the deployed app and confirm the card is created/updated without a 500
- [ ] Confirm `/api/generate-card`, `/api/refresh-myo-playlist`, and `/api/upload-to-myo` still work after a stale login (i.e. after the daily token expiry window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)